### PR TITLE
Настрой анимацию выезда формы

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -448,8 +448,8 @@
   z-index: 1;
   background-color: var(--basic-white);
   box-shadow: 0px 7px 15px var(--special-form-shadow);
-  transition-timing-function: ease-in;
-  animation: appearance 0.6s;
+  animation: appearance 0.4s;
+  animation-timing-function: ease-out;
 }
 
 .modal-search-hotel::after {
@@ -463,7 +463,9 @@
   background: var(--basic-white);
   animation-duration:  0.6s;
   animation-name: disappearance;
-  animation-fill-mode: forwards;
+  animation-timing-function: ease-out;
+  pointer-events: none;
+  opacity: 0;
 }
 
 .visually-none {
@@ -1280,22 +1282,14 @@
 
 @keyframes disappearance {
   0% {
-    transform: translateY(-50%) scaleY(0);
-    z-index: 1;
-  }
-
-  60% {
     opacity: 1;
   }
 
-  80% {
-    z-index: 1;
-    opacity: 0;
+  50% {
+    opacity: 1;
   }
 
   100% {
-    transform: scaleY(1);
-    z-index: -1;
     opacity: 0;
   }
 }


### PR DESCRIPTION
Псевдоэлемент можно просто сделать проницаемым для курсора мыши. Поэтому положение по оси Z менять не нужно. Скейл тоже лишний, сама форма уже скейлится.

Можно укоротить анимацию скейла до 0.4 секунд. Тогда проявление полей будет визуально после конца скейла, но начало проявки в действительности можно начать чуть пораньше конца скейла.

Свойства начинающиеся с transition (в данном случае совйсво временной функции) не действуют на анимацию через animation.

Ну и в нашем случае больше подходит функция ease-out, для более плавного завершения анимации. Но более резкого начала, чтобы действие начиналось сразу же после клика.